### PR TITLE
chore: only publish required files to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,9 @@
     "jest": "^24.9.0",
     "jest-cli": "^24.9.0",
     "lint-staged": "^9.4.3"
-  }
+  },
+  "files": [
+    "index.js",
+    "index.d.ts"
+  ]
 }


### PR DESCRIPTION
Previously a lot of junk was being included in the tarball that was going to NPM. This solves that.

![image](https://user-images.githubusercontent.com/4019718/91876155-acf41a80-ec7c-11ea-90fa-ffb7d99705a0.png)

(license, package.json and readme are always included)

Would appreciate a publish of v1.1.1 after merging this so the effect is actually there for end-users.